### PR TITLE
Fix hugo in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,7 @@ language: go
 go:
 - '1.8'
 install:
-- go get github.com/kardianos/govendor
-- govendor get github.com/gohugoio/hugo
+- go get -v github.com/gohugoio/hugo
 - sudo pip install s3cmd
 script:
 - set -eo pipefail


### PR DESCRIPTION
Seems like govendor + hugo has broken and isn't necessary anymore. Hugo README.md makes no mention of using govendor but its wiki still does, so their docs are not consistent. 