### PR TITLE
Deploy to www.skycoin.net/blog in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,12 @@ before_script:
 - s3cmd --version
 
 script:
-- hugo --buildFuture -v
+- hugo --buildFuture --config config.toml --destination public-blog -v
+- hugo --buildFuture --config config-www.toml --destination public-www -v
 
 after_success:
-- ls public/
+- ls public-blog/
+- ls public-www/
 
 deploy:
   skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,10 @@ after_success:
 deploy:
   skip_cleanup: true
   provider: script
-  script: s3cmd --access_key="${AWS_ACCESS_KEY_ID}" --secret_key="${AWS_SECRET_ACCESS_KEY}" --region=ap-southeast-1 sync --delete-removed --acl-public --guess-mime-type --no-mime-magic --recursive public/ s3://blog.skycoin.net/
+  script: deploy.sh
   on:
     branch: master
 
 after_deploy:
 - s3cmd --access_key="${AWS_ACCESS_KEY_ID}" --secret_key="${AWS_SECRET_ACCESS_KEY}" --region=ap-southeast-1 ls s3://blog.skycoin.net/
+- s3cmd --access_key="${AWS_ACCESS_KEY_ID}" --secret_key="${AWS_SECRET_ACCESS_KEY}" --region=ap-southeast-1 ls s3://www.skycoin.net/blog/

--- a/config-www.toml
+++ b/config-www.toml
@@ -1,0 +1,185 @@
+baseURL = "https://www.skycoin.net/blog"
+languageCode = "en-us"
+title = "Skycoin Blog"
+defaultContentLanguage = "en"
+
+relativeURLs = true
+canonifyURLs = true
+
+googleAnalytics = "UA-105234182-1"
+#disqusShortname = ""
+
+# hugo-xmin specific variables
+theme = "skycoin"
+ignoreFiles = ["\\.Rmd$", "_files$", "_cache$"]
+preserveTaxonomyNames = true
+footnotereturnlinkcontents = "↩"
+
+# enables ```lang ``` style syntax highlighted blocks
+pygmentsCodeFences = true
+pygmentsStyle = "murphy"
+
+[permalinks]
+    post = "/post/:year/:month/:day/:slug/"
+    note = "/note/:year/:month/:day/:slug/"
+
+[[menu.main]]
+    name = "Posts"
+    identifier = "posts"
+    url = "/"
+    weight = 1
+[[menu.main]]
+    name = "Categories"
+    identifier = "categories"
+    url = "/categories/"
+    weight = 2
+[[menu.main]]
+    name = "Tags"
+    identifier = "tags"
+    url = "/tags/"
+    weight = 3
+
+[[menu.footer]]
+  name = "skycoin.net"
+  url = "https://www.skycoin.net/"
+  weight = 1
+
+[[menu.footer]]
+  name = "Github"
+  url = "https://github.com/skycoin"
+  weight = 2
+
+[[menu.footer]]
+  name = "Twitter"
+  url = "https://twitter.com/skycoinproject"
+  weight = 3
+
+[[menu.footer]]
+  name = "Reddit"
+  url = "https://reddit.com/r/SkycoinProject"
+  weight = 4
+
+[[menu.footer]]
+  name = "Telegram"
+  url = "https://t.me/Skycoin"
+  weight = 5
+
+[[menu.footer]]
+  name = "Blockchain Explorer"
+  url = "https://explorer.skycoin.net/"
+  weight = 6
+
+[author]
+  name = "Skycoin"
+
+[params]
+  keywords = "skycoin"
+  rss = "/index.xml"
+  telegram = "https://t.me/Skycoin"
+  description = "Skycoin Project Updates"
+  email = ""
+  github = "skycoin"
+  twitter = "skycoinproject"
+  twitterAnalytics = "ny03t"
+
+[Languages]
+[Languages.en]
+  weight = -1
+  title = "Skycoin Blog"
+  languageName = "English"
+
+[Languages.zh]
+  weight = 1
+  title = "天空币博客"
+  hasCJKLanguage = true
+  languageName = "中文"
+
+[Languages.ru]
+  weight = 2
+  title = "Skycoin Блог"
+  languageName = "Русский"
+
+[Languages.ko]
+  weight = 3
+  title = "Skycoin 블로그"
+  languageName = "한국어"
+
+[Languages.es]
+    weight = 4
+    title = "Skycoin Blog"
+    languageName = "Español"
+
+[Languages.de]
+    weight = 5
+    title = "Skycoin Blog"
+    languageName = "Deutsch"
+
+[Languages.ja]
+    weight = 6
+    title = "Skycoin Blog"
+    languageName = "日本語"
+
+[Languages.el]
+    weight = 7
+    title = "Skycoin Blog"
+    languageName = "Ελληνικά"
+
+[Languages.fr]
+    weight = 8
+    title = "Skycoin Blog"
+    languageName = "Français"
+
+[Languages.pt]
+    weight = 9
+    title = "Skycoin Blog"
+    languageName = "Português"
+
+[Languages.it]
+    weight = 10
+    title = "Skycoin Blog"
+    languageName = "Italiano"
+
+[[menu.languages]]
+  name = "English"
+  weight = -1
+  url = "/"
+[[menu.languages]]
+  name = "中文"
+  weight = 1
+  url = "/zh/"
+[[menu.languages]]
+  name = "Русский"
+  weight = 2
+  url = "/ru/"
+[[menu.languages]]
+  name = "한국어"
+  weight = 3
+  url = "/ko/"
+[[menu.languages]]
+  name = "Español"
+  weight = 4
+  url = "/es/"
+[[menu.languages]]
+  name = "Deutsch"
+  weight = 5
+  url = "/de/"
+[[menu.languages]]
+  name = "日本語"
+  weight = 6
+  url = "/ja/"
+[[menu.languages]]
+  name = "Ελληνικά"
+  weight = 7
+  url = "/el/"
+[[menu.languages]]
+  name = "Français"
+  weight = 8
+  url = "/fr/"
+[[menu.languages]]
+  name = "Português"
+  weight = 9
+  url = "/pt/"
+[[menu.languages]]
+  name = "Italiano"
+  weight = 10
+  url = "/it/"

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
+# Deploy script for travis
+
 # Deploy to blog.skycoin.net
-s3cmd --access_key="${AWS_ACCESS_KEY_ID}" --secret_key="${AWS_SECRET_ACCESS_KEY}" --region=ap-southeast-1 sync --delete-removed --acl-public --guess-mime-type --no-mime-magic --recursive public/ s3://blog.skycoin.net/
+s3cmd --access_key="${AWS_ACCESS_KEY_ID}" --secret_key="${AWS_SECRET_ACCESS_KEY}" --region=ap-southeast-1 sync --delete-removed --acl-public --guess-mime-type --no-mime-magic --recursive public-blog/ s3://blog.skycoin.net/
 
 # Deploy to www.skycoin.net/blog
-s3cmd --access_key="${AWS_ACCESS_KEY_ID}" --secret_key="${AWS_SECRET_ACCESS_KEY}" --region=ap-southeast-1 sync --delete-removed --acl-public --guess-mime-type --no-mime-magic --recursive public/ s3://www.skycoin.net/blog/
+s3cmd --access_key="${AWS_ACCESS_KEY_ID}" --secret_key="${AWS_SECRET_ACCESS_KEY}" --region=ap-southeast-1 sync --delete-removed --acl-public --guess-mime-type --no-mime-magic --recursive public-www/ s3://www.skycoin.net/blog/

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Deploy to blog.skycoin.net
+s3cmd --access_key="${AWS_ACCESS_KEY_ID}" --secret_key="${AWS_SECRET_ACCESS_KEY}" --region=ap-southeast-1 sync --delete-removed --acl-public --guess-mime-type --no-mime-magic --recursive public/ s3://blog.skycoin.net/
+
+# Deploy to www.skycoin.net/blog
+s3cmd --access_key="${AWS_ACCESS_KEY_ID}" --secret_key="${AWS_SECRET_ACCESS_KEY}" --region=ap-southeast-1 sync --delete-removed --acl-public --guess-mime-type --no-mime-magic --recursive public/ s3://www.skycoin.net/blog/

--- a/themes/skycoin/layouts/partials/header.html
+++ b/themes/skycoin/layouts/partials/header.html
@@ -22,7 +22,7 @@
   <header class="header">
     <div class="header__wrapper">
       <div class="header__topnav">
-        <a href="https://skycoin.net" class="header__link">&larr; skycoin.net</a>
+        <a href="https://www.skycoin.net" class="header__link">&larr; skycoin.net</a>
         <div class="js-dropdown header-dropdown">
           {{ $currentLang := .Site.Language.LanguageName }}
           <div class="js-dropdown-current header-dropdown__current">{{ $currentLang }}</div>


### PR DESCRIPTION
This is for transition to www.skycoin.net/blog

Deploy the website to both blog.skycoin.net and www.skycoin.net/blog

This requires two separate configurations to generate the proper URLs.

Later, blog.skycoin.net will be replaced with redirects